### PR TITLE
Delete INIZH.big in Data\INI on First Run

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -1820,6 +1820,10 @@ namespace Contra
                 //Create vpnconfig folder.
                 Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Contra\vpnconfig");
 
+                //Zero Hour has a 'DeleteFile("Data\INI\INIZH.big");' line in GameEngine::init with no condition whatsoever (will always try to delete it if exists)
+                //an identical copy of this file exists in root ZH folder so we can safely delete it before ZH runs to prevent unwanted crashes
+                File.Delete(@"Data\INI\INIZH.big");
+
                 int directoryCount = Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Contra").Length;
 
                 //Show message on first run.


### PR DESCRIPTION
tl;dr No reason to leave it and can cause a crash.
Discussion on thyme's [discord](https://discordapp.com/channels/409121752921276426/409121752921276428/551199579018756097).

Resolves #51.